### PR TITLE
Auto rerender when moving components

### DIFF
--- a/lib/components/CircuitJsonPreview.tsx
+++ b/lib/components/CircuitJsonPreview.tsx
@@ -255,6 +255,7 @@ export const CircuitJsonPreview = ({
                         ? "min-h-[calc(100vh-240px)]"
                         : "min-h-[620px]",
                     )}
+                    onEditEvent={(ee) => onEditEvent?.(ee)}
                     // onEditEventsChanged={(editEvents) => {
                     //   if (editEvents.some((editEvent) => editEvent.in_progress))
                     //     return

--- a/lib/hooks/use-edit-event-controller.ts
+++ b/lib/hooks/use-edit-event-controller.ts
@@ -75,12 +75,25 @@ export const useEditEventController = () => {
 
   useEffect(() => {
     if (editEvents.filter((ee) => !ee._applied).length === 0) return
-    const timeout = setTimeout(() => {
+
+    const handleApply = () => {
       markAllEditEventsApplied()
-      applyEditEventsAndUpdateManualEditsJson(
-        editEvents, //.filter((ee) => !ee._applied),
-      )
-    }, 1000)
+      applyEditEventsAndUpdateManualEditsJson(editEvents)
+    }
+
+    const hasFinishedComponentMove = editEvents.some(
+      (ee) =>
+        !ee._applied &&
+        ee.pcb_edit_event_type === "edit_component_location" &&
+        ee.in_progress === false,
+    )
+
+    if (hasFinishedComponentMove) {
+      handleApply()
+      return
+    }
+
+    const timeout = setTimeout(handleApply, 1000)
 
     return () => clearTimeout(timeout)
   }, [editEvents])


### PR DESCRIPTION
## Summary
- rerender on finished component move without waiting
- forward edit events from PCB viewer

## Testing
- `bun test` *(fails: Cannot find module '@tscircuit/eval-webworker')*

------
https://chatgpt.com/codex/tasks/task_e_684e5656a60c83288da634c19e868c5c