### PR TITLE
fix: ensure dynamic API base for local file server

### DIFF
--- a/lib/components/RunFrameWithApi/RunFrameWithApi.tsx
+++ b/lib/components/RunFrameWithApi/RunFrameWithApi.tsx
@@ -3,7 +3,7 @@ import { useEditEventController } from "lib/hooks/use-edit-event-controller"
 import { useSyncPageTitle } from "lib/hooks/use-sync-page-title"
 import { useEffect, useMemo, useState } from "react"
 import { RunFrame } from "../RunFrame/RunFrame"
-import { API_BASE } from "./api-base"
+import { getApiBase } from "./api-base"
 import { useRunFrameStore } from "./store"
 import { applyEditEventsToManualEditsFile } from "@tscircuit/core"
 import type { ManualEditsFile } from "@tscircuit/props"
@@ -163,7 +163,7 @@ export const RunFrameWithApi = (props: RunFrameWithApiProps) => {
       editEvents={editEventsForRender}
       onEditEvent={(ee) => {
         pushEditEvent(ee)
-        fetch(`${API_BASE}/events/create`, {
+        fetch(`${getApiBase()}/events/create`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -188,7 +188,7 @@ export const RunFrameWithApi = (props: RunFrameWithApiProps) => {
           manualEditsFile: updatedManualEdits,
         })
 
-        fetch(`${API_BASE}/files/upsert`, {
+        fetch(`${getApiBase()}/files/upsert`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({

--- a/lib/components/RunFrameWithApi/api-base.ts
+++ b/lib/components/RunFrameWithApi/api-base.ts
@@ -1,1 +1,6 @@
-export const API_BASE = window.TSCIRCUIT_FILESERVER_API_BASE_URL ?? "/api"
+export const getApiBase = () =>
+  (typeof window !== "undefined" &&
+    (window as any).TSCIRCUIT_FILESERVER_API_BASE_URL) ??
+  "/api"
+
+export const API_BASE = getApiBase()

--- a/lib/components/RunFrameWithApi/store.ts
+++ b/lib/components/RunFrameWithApi/store.ts
@@ -4,7 +4,7 @@ import type { CircuitJson } from "circuit-json"
 import Debug from "lib/utils/debug"
 import { create } from "zustand"
 import { devtools } from "zustand/middleware"
-import { API_BASE } from "./api-base"
+import { getApiBase } from "./api-base"
 import type {
   File,
   FileContent,
@@ -20,7 +20,7 @@ async function upsertFileApi(
   path: FilePath,
   content: FileContent,
 ): Promise<File> {
-  const response = await fetch(`${API_BASE}/files/upsert`, {
+  const response = await fetch(`${getApiBase()}/files/upsert`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ file_path: path, text_content: content }),
@@ -31,7 +31,7 @@ async function upsertFileApi(
 
 async function getFileApi(path: FilePath): Promise<File> {
   const response = await fetch(
-    `${API_BASE}/files/get?file_path=${encodeURIComponent(path)}`,
+    `${getApiBase()}/files/get?file_path=${encodeURIComponent(path)}`,
   )
   const data = await response.json()
   return data.file
@@ -39,15 +39,15 @@ async function getFileApi(path: FilePath): Promise<File> {
 
 async function getEvents(since: string | null): Promise<FileUpdatedEvent[]> {
   const url = since
-    ? `${API_BASE}/events/list?since=${encodeURIComponent(since)}`
-    : `${API_BASE}/events/list`
+    ? `${getApiBase()}/events/list?since=${encodeURIComponent(since)}`
+    : `${getApiBase()}/events/list`
   const response = await fetch(url)
   const data = await response.json()
   return data.event_list
 }
 
 async function getInitialFilesApi(): Promise<Map<FilePath, FileContent>> {
-  const response = await fetch(`${API_BASE}/files/list`)
+  const response = await fetch(`${getApiBase()}/files/list`)
   const { file_list } = (await response.json()) as {
     file_list: Array<{ file_id: string; file_path: string }>
   }

--- a/lib/optional-features/importing/import-component-from-jlcpcb.ts
+++ b/lib/optional-features/importing/import-component-from-jlcpcb.ts
@@ -1,5 +1,5 @@
 import { fetchEasyEDAComponent, convertRawEasyToTsx } from "easyeda/browser"
-import { API_BASE } from "lib/components/RunFrameWithApi/api-base"
+import { getApiBase } from "lib/components/RunFrameWithApi/api-base"
 import ky from "ky"
 
 export const importComponentFromJlcpcb = async (
@@ -9,7 +9,7 @@ export const importComponentFromJlcpcb = async (
   const component = await fetchEasyEDAComponent(jlcpcbPartNumber, {
     // @ts-ignore
     fetch: (url, options: any) => {
-      return fetch(`${API_BASE}/proxy`, {
+      return fetch(`${getApiBase()}/proxy`, {
         ...options,
         headers: {
           ...options?.headers,
@@ -36,7 +36,7 @@ export const importComponentFromJlcpcb = async (
 
   const filePath = `imports/${fileName}.tsx`
 
-  await ky.post(`${API_BASE}/files/upsert`, {
+  await ky.post(`${getApiBase()}/files/upsert`, {
     json: {
       file_path: filePath,
       text_content: tsx,


### PR DESCRIPTION
## Summary
- read file server base URL at runtime via `getApiBase`
- update RunFrame and helpers to use dynamic API base

## Testing
- `bun test` *(fails: Cannot find module '@tscircuit/eval')*
- `bun run format:check` *(fails: biome: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3a69d8c3c8328b7ba089d0d3b1822